### PR TITLE
Add conditional update check and handle 404

### DIFF
--- a/lambda-java/src/main/java/albano/Handler.java
+++ b/lambda-java/src/main/java/albano/Handler.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 
 import java.util.Map;
 
@@ -48,6 +49,10 @@ public class Handler implements
         } catch (IllegalArgumentException | com.fasterxml.jackson.core.JsonProcessingException e) {
             logger.log("⚠️ 400: " + e.getMessage());
             return response(400, e.getMessage());
+
+        } catch (ConditionalCheckFailedException e) {
+            logger.log("⚠️ 404: " + e.getMessage());
+            return response(404, "No encontrada");
 
         } catch (DynamoDbException e) {
             logger.log("❌ Dynamo/SDK error: " + e.getMessage());

--- a/lambda-java/src/main/java/albano/PersonaRepository.java
+++ b/lambda-java/src/main/java/albano/PersonaRepository.java
@@ -68,7 +68,7 @@ public class PersonaRepository {
 
     /* ---------- U  P  D  A  T  E ---------- */
     public Persona update(Persona p) {
-        var resp = ddb.updateItem(UpdateItemRequest.builder()
+        var req = UpdateItemRequest.builder()
                 .tableName(tabla)
                 .key(Map.of(
                         "id", AttributeValue.fromS(p.id())))
@@ -78,8 +78,11 @@ public class PersonaRepository {
                         ":a", AttributeValue.fromS(p.apellido()),
                         ":e", AttributeValue.fromN(Integer.toString(p.edad())),
                         ":q", AttributeValue.fromS(p.equipoFavorito())))
+                .conditionExpression("attribute_exists(id)")
                 .returnValues(ReturnValue.ALL_NEW)
-                .build());
+                .build();
+
+        var resp = ddb.updateItem(req);
 
         var i = resp.attributes();
         return new Persona(


### PR DESCRIPTION
## Summary
- add check in `PersonaRepository.update` to ensure item exists
- respond with `404` when update fails due to missing item

## Testing
- `mvn -f lambda-java/pom.xml package` *(fails: Could not transfer artifact maven-resources-plugin from central)*

------
https://chatgpt.com/codex/tasks/task_e_6855f56003f08329917d1064f7e1e558