### PR TITLE
Reuse DynamoDb client

### DIFF
--- a/lambda-java/src/main/java/albano/Handler.java
+++ b/lambda-java/src/main/java/albano/Handler.java
@@ -23,11 +23,11 @@ public class Handler implements
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    private final DynamoDbClient ddb = DynamoDbClient.builder()
+    private static final DynamoDbClient ddb = DynamoDbClient.builder()
             .region(REGION)           // ⬅ usa constante o lee AWS_REGION
             .build();
 
-    private final PersonaRepository repo = new PersonaRepository(ddb, TABLA);
+    private static final PersonaRepository repo = new PersonaRepository(ddb, TABLA);
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(


### PR DESCRIPTION
## Summary
- avoid creating a new DynamoDbClient per handler
- reuse `PersonaRepository` with the static client

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6855f43d26748329a996116d8915f5ac